### PR TITLE
Add option to include PPI concept ids

### DIFF
--- a/gwas/aou/phenotype_preprocessing/README.md
+++ b/gwas/aou/phenotype_preprocessing/README.md
@@ -13,7 +13,8 @@ Usage example:
    --units blood \
    --range 0,250 \
    [--drugexposure-covariate-concept-ids 21601855:statin] \
-   [--sample samplefile.txt]
+   [--sample samplefile.txt] \
+   [--ppi]
 ```
 
 Required arguments: 
@@ -26,5 +27,6 @@ Required arguments:
 Optional arguments:
 * `--sample <FILE>`: file with list of samples to restrict to (one ID per line). Typically this would a list of samples that passed upstream sample-level QC info.
 * `--drugexposure-covariate-concept-ids <STR>`: List of conceptid:conceptname to use as drug exposure covariates.
+* `--ppi`: Indicate if the phenotype concept id is from the PPI or LOINC (default) tables. PPI are general physical measurements (e.g. hight) and include very limited concept ids.
 
 The output file will is a csv file named `${phenotype}_phenocovar.csv` with columns: "person_id", "phenotype", "age", plus an additional column for each drug exposure named by the "conceptname" provided for that drug. e.g. the example above will have columns "person_id", "phenotype", "age", "statin".

--- a/gwas/aou/phenotype_preprocessing/aou_phenotype_preprocessing.py
+++ b/gwas/aou/phenotype_preprocessing/aou_phenotype_preprocessing.py
@@ -146,13 +146,17 @@ def main():
     parser.add_argument("--drugexposure-covariate-concept-ids", help="Comma-separated list of conceptid:conceptname to use as drug exposure covariates", type=str)
     parser.add_argument("--units", help="Comma-separated list of acceptable units. Accepted shorthands: blood", type=str, required=True)
     parser.add_argument("--range", help="min, max acceptable phenotype values", type=str, required=True)
+    parser.add_argument("--ppi", help="Whether or not the phenotype is from the PPI measurements " + \
+                                      "as opposed to LOINC. Only physical measurements (e.g. height) " + \
+                                      "are in PPI.",
+                                      action="store_true", default=False)
 
     args = parser.parse_args()
     MSG("Processing %s"%args.phenotype)
 
     # Set up dataframes
     demog = SQLToDF(aou_queries.demographics_sql)
-    ptdata = SQLToDF(aou_queries.ConstructTraitSQL(args.concept_id))
+    ptdata = SQLToDF(aou_queries.ConstructTraitSQL(args.concept_id, args.ppi))
     data = pd.merge(ptdata, demog, on="person_id", how="inner")
     MSG("After merge, have %s data points"%data.shape[0])
 
@@ -215,4 +219,3 @@ def main():
 if __name__ == "__main__":
     main()
 
-    

--- a/gwas/aou/phenotype_preprocessing/aou_queries.py
+++ b/gwas/aou/phenotype_preprocessing/aou_queries.py
@@ -156,7 +156,15 @@ def ConstructDrugExposureSQL(concept_id):
                 `""" + os.environ["WORKSPACE_CDR"] + """.concept` d_source_concept 
                     ON d_exposure.drug_source_concept_id = d_source_concept.concept_id"""
 
-def ConstructTraitSQL(concept_id):
+def ConstructTraitSQL(concept_id, ppi):
+    # PPI and LOINC queries are different in two places.
+    # Here we set the values based on PPI or LOINC (default).
+    if ppi:
+        measurement_concept_id = "measurement_source_concept_id"
+        is_standard = "0"
+    else:
+        measurement_concept_id = "measurement_concept_id"
+        is_standard = "1"
     return """
     SELECT
         measurement.person_id,
@@ -192,7 +200,7 @@ def ConstructTraitSQL(concept_id):
             `""" + os.environ["WORKSPACE_CDR"] + """.measurement` measurement 
         WHERE
             (
-                measurement_concept_id IN  (
+                """ + measurement_concept_id + """ IN  (
                     SELECT
                         DISTINCT c.concept_id 
                     FROM
@@ -218,7 +226,7 @@ def ConstructTraitSQL(concept_id):
                             '.%') 
                             OR c.path = a.id) 
                         WHERE
-                            is_standard = 1 
+                            is_standard = """ + is_standard + """
                             AND is_selectable = 1
                         )
                 )  


### PR DESCRIPTION
I added the option to use a concept id within the PPI table (as opposed to the default LOINC) with a flag in `aou_phenotype_preprocessing.py` and appropriate arguments for the respective query generating function in `aou_queries.py`.
By default, LOINC query is called, which is the suitable query for most phenotypes (including blood phenotypes). PPI query is necessary for 8 physical measurement related phenotypes (concept ids) e.g. height, weight, etc.

For more information see [AoU data browser for PPI](https://databrowser.researchallofus.org/physical-measurements/height) with all the 8 different phenotypes and [AoU brief article on types of data](https://support.researchallofus.org/hc/en-us/articles/4619151535508-Types-of-All-of-Us-data-and-how-they-are-organized) for information on the difference of PPI and LOINC data.